### PR TITLE
BUGFIX: Change array_diff to array_diff_key

### DIFF
--- a/code/dataobjects/DataChangeRecord.php
+++ b/code/dataobjects/DataChangeRecord.php
@@ -109,7 +109,7 @@ class DataChangeRecord extends DataObject {
 			// remove any changes to ignored fields
 			$ignored = $changedObject->getIgnoredFields();
 			if($ignored){
-				$changes = array_diff($changes, $ignored);	
+				$changes = array_diff_key($changes, $ignored);	
 				foreach ($ignored as $ignore) {
 					if (isset($changes[$ignore])) {
 						unset($changes[$ignore]);


### PR DESCRIPTION
array_diff doesn't handle multidimensional arrays and we should be comparing the keys of the arrays anyways
